### PR TITLE
Start Photoswipe at clicked element slide

### DIFF
--- a/source/assets/javascripts/lightbox.js
+++ b/source/assets/javascripts/lightbox.js
@@ -1,13 +1,13 @@
 //= require vendor/photoswipe.min
 //= require vendor/photoswipe-ui-default.min
 
-function lightBox() {
+function lightBox(index) {
   var pswpElement = document.querySelectorAll(".pswp")[0];
 
   // build items array
   var slides  = [];
   var figures = document.querySelectorAll(".inline-figure");
-  var options = { index: 0};
+  var options = { index: index };
 
   // document query selector returns an HTMLCollection, not a true array
   // So we need to proxy a true Array object to get forEach

--- a/source/assets/javascripts/ui.js
+++ b/source/assets/javascripts/ui.js
@@ -200,9 +200,14 @@ function popupSetup() {
 function lightBoxSetup() {
   if ($(".inline-figure")) {
     $figures = $(".inline-figure img");
-    $figures.on("click", function() {
-      lightBox();
-      console.log("lightbox called");
+    $figures.on("click", function(e) {
+      var figs = document.querySelectorAll(".inline-figure");
+      var target = _.findIndex(figs, function(figure) {
+        return figure.id == e.target.parentNode.id;
+      });
+
+      console.log(target);
+      lightBox(target);
     });
 
   }


### PR DESCRIPTION
This commit makes Photoswipe aware of the object which triggered it, so
it can start mid-way through the slideshow for example. The lightbox
function now takes an arguemnt, the index of the element it should start
on.

Thanks to Underscore's findIndex function for making this easy!
